### PR TITLE
All jobs now use setup-lisp@v4 where internal caching was implemented.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,13 +24,14 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v4"
         },
         {
           "name": "Setup Common Lisp Environment",
-          "uses": "40ants/setup-lisp@v2",
+          "uses": "40ants/setup-lisp@v4",
           "with": {
-            "asdf-system": "40ants-ci"
+            "asdf-system": "40ants-ci",
+            "cache": "true"
           }
         },
         {
@@ -65,13 +66,14 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v4"
         },
         {
           "name": "Setup Common Lisp Environment",
-          "uses": "40ants/setup-lisp@v2",
+          "uses": "40ants/setup-lisp@v4",
           "with": {
-            "asdf-system": "40ants-ci"
+            "asdf-system": "40ants-ci",
+            "cache": "true"
           }
         },
         {
@@ -110,7 +112,7 @@
           ],
           "lisp": [
             "sbcl-bin",
-            "ccl-bin/1.12.1"
+            "ccl-bin"
           ]
         }
       },
@@ -123,14 +125,15 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v4"
         },
         {
           "name": "Setup Common Lisp Environment",
-          "uses": "40ants/setup-lisp@v2",
+          "uses": "40ants/setup-lisp@v4",
           "with": {
             "asdf-system": "40ants-ci",
-            "qlfile-template": "{% ifequal quicklisp_dist \"ultralisp\" %}\ndist ultralisp http://dist.ultralisp.org\n{% endifequal %}"
+            "qlfile-template": "{% ifequal quicklisp_dist \"ultralisp\" %}\ndist ultralisp http://dist.ultralisp.org\n{% endifequal %}",
+            "cache": "true"
           }
         },
         {

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,13 +24,14 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v4"
         },
         {
           "name": "Setup Common Lisp Environment",
-          "uses": "40ants/setup-lisp@v2",
+          "uses": "40ants/setup-lisp@v4",
           "with": {
-            "asdf-system": "40ants-ci"
+            "asdf-system": "40ants-ci",
+            "cache": "true"
           }
         },
         {

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@
       "steps": [
         {
           "name": "Checkout Code",
-          "uses": "actions/checkout@v3"
+          "uses": "actions/checkout@v4"
         },
         {
           "name": "Create release tag",

--- a/src/changelog.lisp
+++ b/src/changelog.lisp
@@ -11,6 +11,15 @@
 			      "GITHUB_TOKEN"
                               "OSX")
                :external-docs ("https://40ants.com/40ants-asdf-system/"))
+  (0.14.0 2024-02-25
+          "
+Changed
+=======
+
+All jobs now use setup-lisp@v4 where internal caching was implemented.
+
+Also all jobs were switched to from `actions/checkout@v3` to `actions/checkout@v4` action.
+")
   (0.13.0 2023-12-14
           "
 Changed

--- a/src/ci.lisp
+++ b/src/ci.lisp
@@ -21,7 +21,7 @@
   :on-push-to "master"
   :on-pull-request t
   :by-cron "0 10 * * 1"
-  ;; :cache t
+  :cache t
   :jobs ((40ants-ci/jobs/docs:build-docs)))
 
 
@@ -29,7 +29,7 @@
   :on-push-to "master"
   :by-cron "0 10 * * 1"
   :on-pull-request t
-  ;; :cache t
+  :cache t
   :jobs ((40ants-ci/jobs/linter:linter
           :asdf-systems ("40ants-ci"
                          "40ants-ci-tests")
@@ -43,9 +43,7 @@
           :quicklisp ("quicklisp"
                       "ultralisp")
           :lisp ("sbcl-bin"
-                 ;; Version was fixed because of this bug:
-                 ;; https://github.com/roswell/roswell/issues/534
-                 "ccl-bin/1.12.1")
+                 "ccl-bin")
           :coverage t
           :qlfile "{% ifequal quicklisp_dist \"ultralisp\" %}
                    dist ultralisp http://dist.ultralisp.org

--- a/src/core.lisp
+++ b/src/core.lisp
@@ -139,11 +139,11 @@ it will generate `.github/workflows/linter.yml` with following content:
       \"steps\": [
         {
           \"name\": \"Checkout Code\",
-          \"uses\": \"actions/checkout@v3\"
+          \"uses\": \"actions/checkout@v4\"
         },
         {
           \"name\": \"Setup Common Lisp Environment\",
-          \"uses\": \"40ants/setup-lisp@v3\",
+          \"uses\": \"40ants/setup-lisp@v4\",
           \"with\": {
             \"asdf-system\": \"example\"
           }
@@ -285,11 +285,11 @@ It will generate `.github/workflows/ci.yml` with following content:
       \"steps\": [
         {
           \"name\": \"Checkout Code\",
-          \"uses\": \"actions/checkout@v3\"
+          \"uses\": \"actions/checkout@v4\"
         },
         {
           \"name\": \"Setup Common Lisp Environment\",
-          \"uses\": \"40ants/setup-lisp@v3\",
+          \"uses\": \"40ants/setup-lisp@v4\",
           \"with\": {
             \"asdf-system\": \"example\"
           }
@@ -435,11 +435,11 @@ It will generate `.github/workflows/docs.yml` with following content:
       \"steps\": [
         {
           \"name\": \"Checkout Code\",
-          \"uses\": \"actions/checkout@v3\"
+          \"uses\": \"actions/checkout@v4\"
         },
         {
           \"name\": \"Setup Common Lisp Environment\",
-          \"uses\": \"40ants/setup-lisp@v3\",
+          \"uses\": \"40ants/setup-lisp@v4\",
           \"with\": {
             \"asdf-system\": \"example\",
             \"qlfile-template\": \"\"
@@ -484,7 +484,7 @@ Here is the diff of the generated workflow file. It shows steps, added automatic
 modified   .github/workflows/docs.yml
 @@ -20,13 +20,40 @@
            \"name\": \"Checkout Code\",
-           \"uses\": \"actions/checkout@v3\"
+           \"uses\": \"actions/checkout@v4\"
          },
 +        {
 +          \"name\": \"Grant All Perms to Make Cache Restoring Possible\",
@@ -514,7 +514,7 @@ modified   .github/workflows/docs.yml
 +        },
          {
            \"name\": \"Setup Common Lisp Environment\",
-           \"uses\": \"40ants/setup-lisp@v3\",
+           \"uses\": \"40ants/setup-lisp@v4\",
            \"with\": {
              \"asdf-system\": \"40ants-ci\",
              \"qlfile-template\": \"\"

--- a/src/jobs/autotag.lisp
+++ b/src/jobs/autotag.lisp
@@ -56,7 +56,7 @@
 (defmethod 40ants-ci/jobs/job:steps ((job autotag))
   (append (list
            (action "Checkout Code"
-                   "actions/checkout@v3"))
+                   "actions/checkout@v4"))
           (list
            (action "Create release tag"
                    "butlerlogic/action-autotag@8bc1ad456dcdee34e8c6ffbce991cc31793578c2"

--- a/src/jobs/lisp-job.lisp
+++ b/src/jobs/lisp-job.lisp
@@ -8,8 +8,6 @@
                 #:single
                 #:dedent
                 #:current-system-name)
-  (:import-from #:40ants-ci/steps/sh
-                #:sh)
   (:import-from #:40ants-ci/vars
                 #:*use-cache*)
   (:import-from #:serapeum

--- a/src/jobs/lisp-job.lisp
+++ b/src/jobs/lisp-job.lisp
@@ -127,54 +127,20 @@
       (write-string "${{ hashFiles('qlfile.lock', '*.asd') }}" s))))
 
 
-(defgeneric make-cache-steps (job)
-  (:method ((job lisp-job))
-    (when 40ants-ci/vars:*use-cache*
-      (let ((paths-to-cache
-              (list "qlfile"
-                    "qlfile.lock"
-                    "~/.cache/common-lisp/"
-                    "~/.roswell"
-                    "/usr/local/etc/roswell"
-                    "/usr/local/bin/ros"
-                    ;; On OSX Roswell is installed
-                    ;; using Homebrew and /usr/local/bin/ros
-                    ;; is a symlink into a Cellar directory:
-                    "/usr/local/Cellar/roswell"
-                    ".qlot")))
-        (list (sh "Grant All Perms to Make Cache Restoring Possible"
-                  "sudo mkdir -p /usr/local/etc/roswell
-                 sudo chown \"${USER}\" /usr/local/etc/roswell
-                 # Here the ros binary will be restored:
-                 sudo chown \"${USER}\" /usr/local/bin")
-              (sh "Get Current Month"
-                  "echo \"value=$(date -u \"+%Y-%m\")\" >> $GITHUB_OUTPUT"
-                  :id "current-month")
-              (action "Cache Roswell Setup"
-                      "actions/cache@v3"
-                      :id "cache"
-                      :path (format nil "~{~A~^~%~}" paths-to-cache)
-                      :key (make-cache-key job))
-              (sh "Restore Path To Cached Files"
-                  "echo $HOME/.roswell/bin >> $GITHUB_PATH
-                 echo .qlot/bin >> $GITHUB_PATH"
-                  :if "steps.cache.outputs.cache-hit == 'true'"))))))
-
-
 (defmethod 40ants-ci/jobs/job:steps ((job lisp-job))
   (append (list
            (action "Checkout Code"
-                   "actions/checkout@v3"))
-          (make-cache-steps job)
+                   "actions/checkout@v4"))
           (list
            (action "Setup Common Lisp Environment"
-                   "40ants/setup-lisp@v3"
+                   "40ants/setup-lisp@v4"
                    :asdf-system (asdf-system job)
                    :asdf-version (asdf-version job)
                    :roswell-version (roswell-version job)
                    :qlot-version (qlot-version job)
                    :qlfile-template (when (qlfile job)
                                       (dedent (qlfile job)))
-                   :if (when *use-cache*
-                         "steps.cache.outputs.cache-hit != 'true'")))
+                   :cache (if *use-cache*
+                              "true"
+                              "false")))
           (call-next-method)))


### PR DESCRIPTION
Also all jobs were switched to from `actions/checkout@v3` to `actions/checkout@v4` action.