### PR TITLE
New argument CHECKOUT-SUBMODULES was added to jobs.

### DIFF
--- a/docs/changelog.lisp
+++ b/docs/changelog.lisp
@@ -14,6 +14,14 @@
 			      "GITHUB_TOKEN"
                               "OSX")
                :external-docs ("https://40ants.com/40ants-asdf-system/"))
+  (0.18.0 2025-02-25
+          "
+Added
+=====
+
+New argument CHECKOUT-SUBMODULES was added to jobs. By default it is NIL, but if you set this argument to T, then `actions/checkout` action will also download git submodules.
+
+")
   (0.17.0 2025-02-06
           "
 Added

--- a/src/jobs/docs.lisp
+++ b/src/jobs/docs.lisp
@@ -38,13 +38,15 @@
                    lisp
                    asdf-system
                    qlfile
+                   checkout-submodules
                    dynamic-space-size)
   "Creates a job of class BUILD-DOCS."
   (declare (ignore asdf-system error-on-warnings
                    os permissions exclude env steps
                    steps-before steps-after
                    roswell-version asdf-version qlot-version
-                   quicklisp lisp qlfile dynamic-space-size))
+                   quicklisp lisp qlfile dynamic-space-size
+                   checkout-submodules))
   (apply #'make-instance
          'build-docs args))
 

--- a/src/jobs/linter.lisp
+++ b/src/jobs/linter.lisp
@@ -51,6 +51,7 @@
                quicklisp
                lisp
                qlfile
+               checkout-submodules
                dynamic-space-size)
   "Creates a job which will run SBLint for given ASDF systems.
 
@@ -59,7 +60,8 @@
   (declare (ignore check-imports os permissions exclude env
                    steps steps-before steps-after permissions
                    roswell-version asdf-version qlot-version
-                   quicklisp lisp qlfile dynamic-space-size))
+                   quicklisp lisp qlfile dynamic-space-size
+                   checkout-submodules))
   
   (apply #'make-instance
          'linter

--- a/src/jobs/lisp-job.lisp
+++ b/src/jobs/lisp-job.lisp
@@ -22,7 +22,8 @@
            #:asdf-version
            #:roswell-version
            #:qlot-version
-           #:dynamic-space-size))
+           #:dynamic-space-size
+           #:checkout-submodules))
 (in-package 40ants-ci/jobs/lisp-job)
 
 

--- a/src/jobs/lisp-job.lisp
+++ b/src/jobs/lisp-job.lisp
@@ -59,7 +59,12 @@
                  :initform nil
                  :type (or null string)
                  :documentation "Qlot version to use when setting up Lisp environment. If NIL, then will be used version, pinned in `setup-lisp` github action."
-                 :reader qlot-version))
+                 :reader qlot-version)
+   (checkout-submodules :initarg :checkout-submodules
+                        :initform nil
+                        :type (or null boolean)
+                        :documentation "If this flag is true, then we will command actions/checkout action to checkout submodules."
+                        :reader checkout-submodules))
   (:documentation "This job checkouts the sources, installs Roswell and Qlot. Also, it caches results between runs."))
 
 
@@ -138,7 +143,9 @@
 (defmethod 40ants-ci/jobs/job:steps ((job lisp-job))
   (append (list
            (action "Checkout Code"
-                   "actions/checkout@v4"))
+                   "actions/checkout@v4"
+                   :submodules (when (checkout-submodules job)
+                                 t)))
           (list
            (action "Setup Common Lisp Environment"
                    "40ants/setup-lisp@v4"

--- a/src/jobs/lisp-job.lisp
+++ b/src/jobs/lisp-job.lisp
@@ -140,6 +140,7 @@
       (write-string "${{ hashFiles('qlfile.lock', '*.asd') }}" s))))
 
 
+;; ignore-critiques: needless-when
 (defmethod 40ants-ci/jobs/job:steps ((job lisp-job))
   (append (list
            (action "Checkout Code"
@@ -157,6 +158,6 @@
                                       (dedent (qlfile job)))
                    :dynamic-space-size (dynamic-space-size job)
                    :cache (if *use-cache*
-                            "true"
-                            "false")))
+                              "true"
+                              "false")))
           (call-next-method)))

--- a/src/jobs/run-tests.lisp
+++ b/src/jobs/run-tests.lisp
@@ -45,6 +45,7 @@
                              qlfile
                              quicklisp
                              asdf-system
+                             checkout-submodules
                              dynamic-space-size)
   "Creates a job step of class RUN-TESTS."
   (declare (ignore coverage qlfile
@@ -55,7 +56,8 @@
                    steps-after
                    env
                    roswell-version asdf-version qlot-version lisp
-                   exclude qlfile quicklisp asdf-system dynamic-space-size))
+                   exclude qlfile quicklisp asdf-system dynamic-space-size
+                   checkout-submodules))
   (check-type custom
               (or null string list))
   (apply #'make-instance 'run-tests

--- a/src/steps/action.lisp
+++ b/src/steps/action.lisp
@@ -34,8 +34,11 @@
   (append
    `(("uses" . ,(uses action)))
    (when (action-args action)
-     `(("with" . ,(loop for (name value) on (action-args action) by #'cddr
-                        when value
-                          collect (cons
-                                   (string-downcase name)
-                                   value)))))))
+     (let ((collected-args
+             (loop for (name value) on (action-args action) by #'cddr
+                   when value
+                   collect (cons
+                            (string-downcase name)
+                            value))))
+       (when collected-args
+         `(("with" . ,collected-args)))))))


### PR DESCRIPTION
By default it is NIL, but if you set this argument to T, then `actions/checkout` action will also download git submodules.